### PR TITLE
This fixes various issues with the centos CI tests

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -88,7 +88,7 @@ class ceph::repo (
         baseurl    => absent,
         gpgcheck   => '0',
         gpgkey     => absent,
-        mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        mirrorlist => 'http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         priority   => '20', # prefer ceph repos over EPEL
         tag        => 'ceph',
       }

--- a/spec/classes/ceph_repo_spec.rb
+++ b/spec/classes/ceph_repo_spec.rb
@@ -200,7 +200,7 @@ describe 'ceph::repo' do
         :baseurl    => 'absent',
         :gpgcheck   => '0',
         :gpgkey     => 'absent',
-        :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        :mirrorlist => 'http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :priority   => '20'
       ) }
 
@@ -241,7 +241,7 @@ describe 'ceph::repo' do
         :baseurl    => 'absent',
         :gpgcheck   => '0',
         :gpgkey     => 'absent',
-        :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        :mirrorlist => 'http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :priority   => '20'
       ) }
 
@@ -284,7 +284,7 @@ describe 'ceph::repo' do
         :baseurl    => 'absent',
         :gpgcheck   => '0',
         :gpgkey     => 'absent',
-        :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        :mirrorlist => 'http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :priority   => '20'
       ) }
 
@@ -348,7 +348,7 @@ describe 'ceph::repo' do
         :baseurl    => 'absent',
         :gpgcheck   => '0',
         :gpgkey     => 'absent',
-        :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        :mirrorlist => 'http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :priority   => '20'
       ) }
 
@@ -401,7 +401,7 @@ describe 'ceph::repo' do
         :baseurl    => 'absent',
         :gpgcheck   => '0',
         :gpgkey     => 'absent',
-        :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        :mirrorlist => 'http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :priority   => '20'
       ) }
 

--- a/spec/system/ceph_key_spec.rb
+++ b/spec/system/ceph_key_spec.rb
@@ -49,7 +49,6 @@ describe 'ceph::key' do
       package { [
          'python-ceph',
          'ceph-common',
-         'curl',
          'librados2',
          'librbd1',
          'libcephfs1',

--- a/spec/system/ceph_mon_spec.rb
+++ b/spec/system/ceph_mon_spec.rb
@@ -26,7 +26,7 @@ describe 'ceph::mon' do
   fsid = 'a4807c9a-e76f-4666-a297-6d6cbc922e3a'
   mon_host = '$::ipaddress_eth1'
   # passing it directly as unqoted array is not supported everywhere
-  packages = "[ 'python-ceph', 'ceph-common', 'curl', 'librados2', 'librbd1', 'libcephfs1' ]"
+  packages = "[ 'python-ceph', 'ceph-common', 'librados2', 'librbd1', 'libcephfs1' ]"
 
   releases.each do |release|
 

--- a/spec/system/ceph_mons_spec.rb
+++ b/spec/system/ceph_mons_spec.rb
@@ -301,7 +301,7 @@ scenario: 2_role
           file.unlink
         end
 
-        shell(:node => vm, :command => "sed -i '/^node_terminus.*=.*scenario$/d' /etc/puppet/puppet.conf")
+        shell(:node => vm, :command => "sed -i '/^\\s*node_terminus\\s*=\\s*scenario\\s*$/d' /etc/puppet/puppet.conf")
         shell(:node => vm, :command => 'rm -rf /etc/puppet/data')
       end
     end

--- a/spec/system/ceph_osd_spec.rb
+++ b/spec/system/ceph_osd_spec.rb
@@ -28,7 +28,7 @@ describe 'ceph::osd' do
   admin_key = 'AQA0TVRTsP/aHxAAFBvntu1dSEJHxtJeFFrRsg=='
   mon_host = '$::ipaddress_eth1'
   # passing it directly as unqoted array is not supported everywhere
-  packages = "[ 'python-ceph', 'ceph-common', 'curl', 'librados2', 'librbd1', 'libcephfs1' ]"
+  packages = "[ 'python-ceph', 'ceph-common', 'librados2', 'librbd1', 'libcephfs1' ]"
 
   purge = <<-EOS
     ceph::mon { 'a': ensure => absent }

--- a/spec/system/ceph_osds_spec.rb
+++ b/spec/system/ceph_osds_spec.rb
@@ -93,7 +93,7 @@ second: osd
         file.unlink
       end
 
-      shell(:node => vm, :command => "sed -i '/^node_terminus.*=.*scenario$/d' /etc/puppet/puppet.conf")
+      shell(:node => vm, :command => "sed -i '/^\\s*node_terminus\\s*=\\s*scenario\\s*$/d' /etc/puppet/puppet.conf")
       shell(:node => vm, :command => 'rm -rf /etc/puppet/data')
     end
   end

--- a/spec/system/ceph_pool_spec.rb
+++ b/spec/system/ceph_pool_spec.rb
@@ -35,7 +35,6 @@ describe 'ceph::pool' do
       package { [
          'python-ceph',
          'ceph-common',
-         'curl',
          'librados2',
          'librbd1',
          'libcephfs1',

--- a/spec/system/ceph_profile_base_spec.rb
+++ b/spec/system/ceph_profile_base_spec.rb
@@ -28,7 +28,7 @@ describe 'ceph::profile::base' do
   releases = ENV['RELEASES'] ? ENV['RELEASES'].split : release2version.keys
   machines = ENV['MACHINES'] ? ENV['MACHINES'].split : [ 'first', 'second' ]
   # passing it directly as unqoted array is not supported everywhere
-  packages = "[ 'python-ceph', 'ceph-common', 'curl', 'librados2', 'librbd1', 'libcephfs1' ]"
+  packages = "[ 'python-ceph', 'ceph-common', 'librados2', 'librbd1', 'libcephfs1' ]"
   fsid = 'a4807c9a-e76f-4666-a297-6d6cbc922e3a'
   hieradata_common = '/var/lib/hiera/common.yaml'
   hiera_shared = <<-EOS

--- a/spec/system/ceph_repo_spec.rb
+++ b/spec/system/ceph_repo_spec.rb
@@ -172,7 +172,7 @@ describe 'ceph::repo' do
         end
       end
 
-      it "should find curl in ceph-extras" do
+      it "should find curl/qemu-kvm in ceph-extras" do
         osfamily = facter.facts['osfamily']
 
         pp = <<-EOS
@@ -189,7 +189,7 @@ describe 'ceph::repo' do
           r.exit_code.should_not == 1
         end
 
-        # Test for a package in ceph-extras (curl)
+        # Test for a package in ceph-extras (curl/qemu-kvm)
         if osfamily == 'Debian'
           shell 'apt-cache policy curl' do |r|
             r.stdout.should =~ /ceph\.com.*ceph-extras/


### PR DESCRIPTION
As the centos CI tests haven't been run for a while various issues
have accumulated:

- due to POODLE, downloading the EPEL mirror list doesn't work over https
  anymore. Switched to http. As packages are still verified via GPG, this
  shouldn't be unsafe.
- when adding tests for extra repositories curl was removed as a workaround,
  that's not a valid operation under centos, as yum depends on it.
- the recently applied fix for SNT didn't work under centos yet, due to
  additional whitespace.

Change-Id: I583ceb38cec72ae908dbdd5e6d937ed09058f446