### PR TITLE
Enabling and fixing the rspec tests for profiles

### DIFF
--- a/spec/classes/ceph_profile_client_spec.rb
+++ b/spec/classes/ceph_profile_client_spec.rb
@@ -37,9 +37,7 @@ describe 'ceph::profile::client' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile client'
+    it_configures 'ceph profile client'
   end
 
   context 'on Ubuntu' do
@@ -52,9 +50,7 @@ describe 'ceph::profile::client' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile client'
+    it_configures 'ceph profile client'
   end
 
   context 'on RHEL6' do
@@ -66,9 +62,7 @@ describe 'ceph::profile::client' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile client'
+    it_configures 'ceph profile client'
   end
 end
 # Local Variables:

--- a/spec/classes/ceph_profile_mon_spec.rb
+++ b/spec/classes/ceph_profile_mon_spec.rb
@@ -24,7 +24,7 @@ describe 'ceph::profile::mon' do
       :authentication_type => 'cephx',
       :key                 => 'AQATGHJTUCBqIBAA7M2yafV1xctn1pgr3GcKPg==')
     }
-    it { should contain_ceph__key('client.admin').that_requires('Ceph::Mon[first]').with(
+    it { should contain_ceph__key('client.admin').with(
       :secret          => 'AQBMGHJTkC8HKhAAJ7NH255wYypgm1oVuV41MA==',
       :cap_mon         => 'allow *',
       :cap_osd         => 'allow *',
@@ -34,7 +34,7 @@ describe 'ceph::profile::mon' do
       :inject_as_id    => 'mon.',
       :inject_keyring  => '/var/lib/ceph/mon/ceph-first/keyring')
     }
-    it { should contain_ceph__key('client.bootstrap-osd').that_requires('Ceph::Mon[first]').with(
+    it { should contain_ceph__key('client.bootstrap-osd').with(
       :secret          => 'AQARG3JTsDDEHhAAVinHPiqvJkUi5Mww/URupw==',
       :keyring_path    => '/var/lib/ceph/bootstrap-osd/ceph.keyring',
       :cap_mon         => 'allow profile bootstrap-osd',
@@ -42,7 +42,7 @@ describe 'ceph::profile::mon' do
       :inject_as_id    => 'mon.',
       :inject_keyring  => '/var/lib/ceph/mon/ceph-first/keyring')
     }
-    it { should contain_ceph__key('client.bootstrap-mds').that_requires('Ceph::Mon[first]').with(
+    it { should contain_ceph__key('client.bootstrap-mds').with(
       :secret          => 'AQCztJdSyNb0NBAASA2yPZPuwXeIQnDJ9O8gVw==',
       :keyring_path    => '/var/lib/ceph/bootstrap-mds/ceph.keyring',
       :cap_mon         => 'allow profile bootstrap-mds',
@@ -63,9 +63,7 @@ describe 'ceph::profile::mon' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile mon'
+    it_configures 'ceph profile mon'
   end
 
   context 'on Ubuntu' do
@@ -79,9 +77,7 @@ describe 'ceph::profile::mon' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile mon'
+    it_configures 'ceph profile mon'
   end
 
   context 'on RHEL6' do
@@ -94,9 +90,7 @@ describe 'ceph::profile::mon' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile mon'
+    it_configures 'ceph profile mon'
   end
 
 end

--- a/spec/classes/ceph_profile_osd_spec.rb
+++ b/spec/classes/ceph_profile_osd_spec.rb
@@ -58,9 +58,7 @@ describe 'ceph::profile::osd' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile osd'
+    it_configures 'ceph profile osd'
   end
 
   describe 'on Ubuntu' do
@@ -73,9 +71,7 @@ describe 'ceph::profile::osd' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile osd'
+    it_configures 'ceph profile osd'
   end
 
   describe 'on RedHat' do
@@ -87,9 +83,7 @@ describe 'ceph::profile::osd' do
       }
     end
 
-    # dont actually run any tests. these cannot run under puppet 2.7
-    # TODO: uncomment once 2.7 is deprecated
-    #it_configures 'ceph profile osd'
+    it_configures 'ceph profile osd'
   end
 end
 # Local Variables:


### PR DESCRIPTION
Because Puppet 2.7 has been deprecated the rspec tests for the
profile classes which require hiera autolookup can now be enabled.

At the same time they became out of sync because they weren't run
and are now updated to work with the current code again.

Change-Id: I8b62e111871f999c8535880cc17627878c53f35e