### PR TITLE
define ceph::rgw::keystone.

### DIFF
--- a/manifests/rgw/keystone.pp
+++ b/manifests/rgw/keystone.pp
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2014 Catalyst IT Limited.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Author: Ricardo Rocha <ricardo@catalyst.net.nz>
+#
+# Configures keystone auth/authz for the ceph radosgw.
+#
+### == Name
+#
+# The RGW id. An alphanumeric string uniquely identifying the RGW.
+# ( example: radosgw.gateway )
+#
+### == Parameters
+#
+# [*rgw_keystone_url*] The internal or admin url for keystone.
+#   Mandatory.
+#
+# [*rgw_keystone_admin*] The keystone admin token.
+#   Mandatory.
+#
+# [*rgw_keystone_accepted_roles*] Roles to accept from keystone.
+#   Optional. Default is '_member_, Member'.
+#   Comma separated list of roles.
+#
+# [*rgw_keystone_token_cache_size*] How many tokens to keep cached.
+#   Optional. Default is 500.
+#   Not useful when using PKI as every token is checked.
+#
+# [*rgw_keystone_revocation_interval*] Interval to check for expired tokens.
+#   Optional. Default is 600 (seconds).
+#   Not useful if not using PKI tokens (if not, set to high value).
+#
+# [*use_pki*] (bool) To determine if keystone is using token_format.
+#   Optional. Default is undef.
+#
+# [*nss_db_path*] Path to NSS < - > keystone tokens db files.
+#   Optional. Default is undef.
+#
+define ceph::rgw::keystone (
+  $rgw_keystone_url,
+  $rgw_keystone_admin_token,
+  $rgw_keystone_accepted_roles = '_member_, Member',
+  $rgw_keystone_token_cache_size = 500,
+  $rgw_keystone_revocation_interval = 600,
+  $use_pki = undef,
+  $nss_db_path = '/var/lib/ceph/nss',
+) {
+
+  ceph_config {
+    "client.${name}/rgw_keystone_url":                 value => $rgw_keystone_url;
+    "client.${name}/rgw_keystone_admin_token":         value => $rgw_keystone_admin_token;
+    "client.${name}/rgw_keystone_accepted_roles":      value => $rgw_keystone_accepted_roles;
+    "client.${name}/rgw_keystone_token_cache_size":    value => $rgw_keystone_token_cache_size;
+    "client.${name}/rgw_keystone_revocation_interval": value => $rgw_keystone_revocation_interval;
+    "client.${name}/rgw_s3_auth_use_keystone":         value => true;
+    "client.${name}/use_pki":                          value => $use_pki;
+    "client.${name}/nss_db_path":                      value => $nss_db_path;
+  }
+
+  # fetch the keystone signing cert, add to nss db
+  ensure_resource('package', 'libnss3-tools', {'ensure' => 'present'})
+
+  file { $nss_db_path:
+    ensure => directory,
+    owner  => root,
+    group  => root,
+  }
+
+  exec { "${name}-nssdb-ca":
+    command => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+wget --no-check-certificate ${rgw_keystone_url}/certificates/ca -O /tmp/ca
+openssl x509 -in /tmp/ca -pubkey | certutil -A -d ${nss_db_path} -n ca -t \"TCu,Cu,Tuw\"
+",
+    unless  => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+certutil -d ${nss_db_path} -L | grep ^ca
+",
+  }
+
+  exec { "${name}-nssdb-signing":
+    command => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+wget --no-check-certificate ${rgw_keystone_url}/certificates/signing -O /tmp/signing
+openssl x509 -in /tmp/signing -pubkey | certutil -A -d ${nss_db_path} -n signing_cert -t \"P,P,P\"
+",
+    unless  => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+certutil -d ${nss_db_path} -L | grep ^signing_cert
+",
+  }
+
+  Package['libnss3-tools']
+  -> Package[$::ceph::params::packages]
+  -> File[$nss_db_path]
+  -> Exec["${name}-nssdb-ca"]
+  -> Exec["${name}-nssdb-signing"]
+  ~> Service["radosgw-${name}"]
+
+}

--- a/spec/defines/ceph_rgw_keystone_spec.rb
+++ b/spec/defines/ceph_rgw_keystone_spec.rb
@@ -1,0 +1,169 @@
+#
+# Copyright (C) 2014 Catalyst IT Limited.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Author: Ricardo Rocha <ricardo@catalyst.net.nz>
+#
+
+require 'spec_helper'
+
+describe 'ceph::rgw::keystone' do
+
+  shared_examples_for 'ceph rgw keystone' do
+
+    describe "create with default params" do
+
+      let :pre_condition do
+        "
+          include ceph::params
+          class { 'ceph': fsid => 'd5252e7d-75bc-4083-85ed-fe51fa83f62b' }
+          class { 'ceph::repo': extras => true, fastcgi => true, }
+          include ceph
+          ceph::rgw { 'radosgw.gateway': }
+          ceph::rgw::apache { 'radosgw.gateway': }
+        "
+      end
+
+      let :title do
+        'radosgw.gateway'
+      end
+
+      let :params do
+        {
+          :rgw_keystone_url         => 'http://keystone.default:5000/v2.0',
+          :rgw_keystone_admin_token => 'defaulttoken',
+        }
+      end
+
+      it { should contain_ceph_config('client.radosgw.gateway/rgw_keystone_url').with_value('http://keystone.default:5000/v2.0') }
+      it { should contain_ceph_config('client.radosgw.gateway/rgw_keystone_admin_token').with_value('defaulttoken') }
+      it { should contain_ceph_config('client.radosgw.gateway/rgw_keystone_accepted_roles').with_value('_member_, Member') }
+      it { should contain_ceph_config('client.radosgw.gateway/rgw_keystone_token_cache_size').with_value(500) }
+      it { should contain_ceph_config('client.radosgw.gateway/rgw_keystone_revocation_interval').with_value(600) }
+      it { should contain_ceph_config('client.radosgw.gateway/use_pki').with_value('') }
+      it { should contain_ceph_config('client.radosgw.gateway/nss_db_path').with_value('/var/lib/ceph/nss') }
+
+      it { should contain_exec('radosgw.gateway-nssdb-ca').with(
+         'command' => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+wget --no-check-certificate http://keystone.default:5000/v2.0/certificates/ca -O /tmp/ca
+openssl x509 -in /tmp/ca -pubkey | certutil -A -d /var/lib/ceph/nss -n ca -t \"TCu,Cu,Tuw\"
+"
+      ) }
+      it { should contain_exec('radosgw.gateway-nssdb-signing').with(
+         'command' => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+wget --no-check-certificate http://keystone.default:5000/v2.0/certificates/signing -O /tmp/signing
+openssl x509 -in /tmp/signing -pubkey | certutil -A -d /var/lib/ceph/nss -n signing_cert -t \"P,P,P\"
+"
+      ) }
+
+    end
+
+    describe "create with custom params" do
+
+      let :pre_condition do
+        "
+          include ceph::params
+          class { 'ceph': fsid => 'd5252e7d-75bc-4083-85ed-fe51fa83f62b' }
+          class { 'ceph::repo': extras => true, fastcgi => true, }
+          ceph::rgw { 'radosgw.custom': }
+          ceph::rgw::apache { 'radosgw.custom': }
+        "
+      end
+
+      let :title do
+        'radosgw.custom'
+      end
+
+      let :params do
+        {
+          :rgw_keystone_url                 => 'http://keystone.custom:5000/v2.0',
+          :rgw_keystone_admin_token         => 'mytoken',
+          :rgw_keystone_accepted_roles      => '_role1_,role2',
+          :rgw_keystone_token_cache_size    => 100,
+          :rgw_keystone_revocation_interval => 200,
+          :use_pki                          => false,
+          :nss_db_path                      => '/some/path/to/nss',
+        }
+      end
+
+      it { should contain_ceph_config('client.radosgw.custom/rgw_keystone_url').with_value('http://keystone.custom:5000/v2.0') }
+      it { should contain_ceph_config('client.radosgw.custom/rgw_keystone_admin_token').with_value('mytoken') }
+      it { should contain_ceph_config('client.radosgw.custom/rgw_keystone_accepted_roles').with_value('_role1_,role2') }
+      it { should contain_ceph_config('client.radosgw.custom/rgw_keystone_token_cache_size').with_value(100) }
+      it { should contain_ceph_config('client.radosgw.custom/rgw_keystone_revocation_interval').with_value(200) }
+      it { should contain_ceph_config('client.radosgw.custom/use_pki').with_value(false) }
+      it { should contain_ceph_config('client.radosgw.custom/nss_db_path').with_value('/some/path/to/nss') }
+
+      it { should contain_exec('radosgw.custom-nssdb-ca').with(
+         'command' => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+wget --no-check-certificate http://keystone.custom:5000/v2.0/certificates/ca -O /tmp/ca
+openssl x509 -in /tmp/ca -pubkey | certutil -A -d /some/path/to/nss -n ca -t \"TCu,Cu,Tuw\"
+"
+      ) }
+      it { should contain_exec('radosgw.custom-nssdb-signing').with(
+         'command' => "/bin/true  # comment to satisfy puppet syntax requirements
+set -ex
+wget --no-check-certificate http://keystone.custom:5000/v2.0/certificates/signing -O /tmp/signing
+openssl x509 -in /tmp/signing -pubkey | certutil -A -d /some/path/to/nss -n signing_cert -t \"P,P,P\"
+"
+      ) }
+
+    end
+
+  end
+
+  describe 'Debian Family' do
+
+    let :facts do
+      {
+        :concat_basedir         => '/var/lib/puppet/concat',
+        :fqdn                   => 'myhost.domain',
+        :hostname               => 'myhost',
+        :lsbdistcodename        => 'precise',
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Ubuntu',
+        :operatingsystemrelease => '12.04',
+      }
+    end
+
+    it_configures 'ceph rgw keystone'
+  end
+
+  describe 'RedHat Family' do
+
+    let :facts do
+      {
+        :concat_basedir         => '/var/lib/puppet/concat',
+        :fqdn                   => 'myhost.domain',
+        :hostname               => 'myhost',
+        :lsbdistcodename        => 'Final',
+        :osfamily               => 'RedHat',
+        :operatingsystem        => 'RedHat',
+        :operatingsystemrelease => '6',
+      }
+    end
+
+    it_configures 'ceph rgw keystone'
+  end
+end
+
+# Local Variables:
+# compile-command: "cd ../.. ;
+#    bundle install ;
+#    bundle exec rake spec
+# "
+# End:

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -51,6 +51,10 @@ RSpec.configure do |c|
             :node => vm)
       shell(:command => 'puppet module install --version 1.0.1 puppetlabs/apache',
             :node => vm)
+      shell(:command => 'puppet module install --version 0.9.0 puppetlabs/mysql',
+            :node => vm)
+      shell(:command => 'puppet module install --version 4.1.0 puppetlabs/keystone',
+            :node => vm)
       rcp(:sp => File.join(proj_root, 'spec/fixtures/hieradata/hiera.yaml'),
           :dp => '/etc/puppet/hiera.yaml',
           :d => node(:name => vm))

--- a/spec/system/ceph_rgw_keystone_spec.rb
+++ b/spec/system/ceph_rgw_keystone_spec.rb
@@ -1,0 +1,271 @@
+#
+# Copyright (C) 2014 Catalyst IT Limited.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Author: Ricardo Rocha <ricardo@catalyst.net.nz>
+#
+require 'spec_helper_system'
+
+describe 'ceph::rgw::keystone' do
+
+  purge = <<-EOS
+   package { [
+      'python-ceph',
+      'ceph-common',
+      'librados2',
+      'librbd1',
+      'radosgw',
+     ]:
+     ensure => purged
+   }
+  EOS
+
+  releases = ENV['RELEASES'] ? ENV['RELEASES'].split : [ 'dumpling', 'emperor', 'firefly' ]
+  fsid = 'a4807c9a-e76f-4666-a297-6d6cbc922e3a'
+  admin_key = 'AQA0TVRTsP/aHxAAFBvntu1dSEJHxtJeFFrRsg=='
+  radosgw_key = 'AQA0TVRTsP/aHxAAFBvntu1dSEJHxtJeFFrRwg=='
+
+  keystone_admin_token = 'keystonetoken'
+  keystone_password = '123456'
+  keystone_db_password = '123456'
+
+  releases.each do |release|
+    describe release, :cephx do
+      it 'should install one monitor/osd with a rgw' do
+        pp = <<-EOS
+          $user = $::osfamily ? {
+            'RedHat' => 'apache',
+            default => 'www-data',
+          }
+
+          $pkg_swift = $osfamily ? {
+            'RedHat' => 'openstack-swift',
+            default  => 'swift',
+          }
+
+          # setup a keystone instance (need havana at least)
+          include apt
+          apt::source { 'cloudarchive-havana':
+            location          => 'http://ubuntu-cloud.archive.canonical.com/ubuntu',
+            release           => 'precise-updates/havana',
+            repos             => 'main',
+            include_src       => false,
+            required_packages => 'ubuntu-cloud-keyring',
+          }
+
+          class { 'mysql::server': }
+          ->
+          class { 'keystone::db::mysql':
+            password      => '#{keystone_db_password}',
+            allowed_hosts => '%',
+          }
+          ->
+          class { 'keystone':
+            verbose             => True,
+            catalog_type        => 'sql',
+            admin_token         => '#{keystone_admin_token}',
+            database_connection => "mysql://keystone_admin:#{keystone_db_password}@${::ipaddress}/keystone",
+            admin_endpoint      => "http://${::ipaddress}:35357/v2.0",
+          }
+          ->
+          class { 'keystone::roles::admin':
+            email        => 'admin@example.com',
+            password     => '#{keystone_password}',
+          }
+          ->
+          class { 'keystone::endpoint':
+            public_url   => "http://${::ipaddress}:5000/v2.0",
+            admin_url    => "http://${::ipaddress}:35357/v2.0",
+            internal_url => "http://${::ipaddress}:5000/v2.0",
+            region       => 'example-1',
+          }
+
+          # default pools size to 1 for local test
+          Ceph::Pool {
+            size => 1,
+          }
+          ceph::pool { 'data': }
+          ceph::pool { 'metadata': }
+          ceph::pool { 'rbd': }
+          # we declare the rgw pool here even if they're created by the
+          # daemon to make sure we get a replica of 1
+          ceph::pool { '.rgw': }
+          ceph::pool { '.rgw.control': }
+          ceph::pool { '.rgw.gc': }
+          ceph::pool { '.rgw.root': }
+          ceph::pool { '.users': }
+          ceph::pool { '.users.uid': }
+          ceph::pool { '.users.swift': }
+
+          ceph_config {
+           'global/mon_data_avail_warn': value => 10; # FIXME: workaround for health warn in mon
+           'global/osd_journal_size':    value => '100';
+          }
+
+          # ceph setup
+          class { 'ceph::repo':
+            release => '#{release}',
+            extras  => true,
+            fastcgi => true,
+          }
+          ->
+          class { 'ceph':
+            fsid => '#{fsid}',
+            mon_host => $::ipaddress_eth0,
+          }
+          ->
+          ceph::mon { 'a':
+            public_addr => $::ipaddress_eth0,
+            key => 'AQCztJdSyNb0NBAASA2yPZPuwXeIQnDJ9O8gVw==',
+          }
+          ->
+          ceph::key { 'client.admin':
+            secret         => '#{admin_key}',
+            cap_mon        => 'allow *',
+            cap_osd        => 'allow *',
+            cap_mds        => 'allow *',
+            inject         => true,
+            inject_as_id   => 'mon.',
+            inject_keyring => '/var/lib/ceph/mon/ceph-a/keyring',
+          }
+          ->
+          ceph::key { 'client.radosgw.gateway':
+            user    => $user,
+            secret  => '#{radosgw_key}',
+            cap_mon => 'allow rw',
+            cap_osd => 'allow rwx',
+            inject  => true,
+          }
+          ->
+          exec { 'bootstrap-key':
+            command => '/usr/sbin/ceph-create-keys --id a',
+          }
+          ->
+          ceph::osd { '/srv/data': }
+
+          # setup ceph radosgw
+          host { $::fqdn: # workaround for bad 'hostname -f' in vagrant box
+            ip => $ipaddress,
+          }
+          ->
+          file { '/var/run/ceph': # workaround for bad sysvinit script (ignores socket)
+            ensure => directory,
+            owner  => $user,
+          }
+          ->
+          ceph::rgw { 'radosgw.gateway':
+            rgw_port        => 80,
+            rgw_socket_path => '/var/run/ceph/ceph-client.radosgw.gateway.asok',
+          }
+          ->
+          package { $pkg_swift:  # required for tests below
+            ensure => present,
+          }
+          Ceph::Osd['/srv/data'] -> Service['radosgw-radosgw.gateway']
+
+          ceph::rgw::apache { 'radosgw.gateway':
+            rgw_port        => 80,
+            rgw_socket_path => '/var/run/ceph/ceph-client.radosgw.gateway.asok',
+          }
+
+          # add the require keystone endpoints for radosgw (object-store)
+          ceph::rgw::keystone { 'radosgw.gateway':
+            rgw_keystone_url         => "http://${::ipaddress}:5000/v2.0",
+            rgw_keystone_admin_token => '#{keystone_admin_token}',
+          }
+          Service['keystone'] -> Ceph::Rgw::Keystone['radosgw.gateway']
+
+          keystone_service { 'swift':
+            ensure => present,
+            type => 'object-store',
+            description => 'Openstack Object Storage Service',
+          }
+          keystone_endpoint { 'example-1/swift':
+            ensure => present,
+            public_url => "http://${::ipaddress}:80/swift/v1",
+            admin_url => "http://${::ipaddress}:80/swift/v1",
+            internal_url => "http://${::ipaddress}:80/swift/v1",
+          }
+          Keystone_service<||> -> Ceph::Rgw::Keystone['radosgw.gateway']
+          Keystone_endpoint<||> -> Ceph::Rgw::Keystone['radosgw.gateway']
+
+          # add a testuser for validation below
+          keystone_user { 'testuser':
+            ensure   => present,
+            enabled  => True,
+            email    => 'testuser@example',
+            password => '123456',
+            tenant   => 'openstack',
+          }
+          Keystone_user<||> -> Ceph::Rgw::Keystone['radosgw.gateway']
+
+          keystone_user_role { 'testuser@openstack':
+            ensure => present,
+            roles  => ['_member_'],
+          }
+          Keystone_user_role<||> -> Ceph::Rgw::Keystone['radosgw.gateway']
+
+        EOS
+
+        osfamily = facter.facts['osfamily']
+        servicequery = {
+          'Debian' => 'status radosgw id=radosgw.gateway',
+          'RedHat' => 'service ceph-radosgw status id=radosgw.gateway',
+        }
+
+        puppet_apply(pp) do |r|
+          r.exit_code.should_not == 1
+          r.refresh
+          r.exit_code.should_not == 1
+        end
+
+        shell servicequery[osfamily] do |r|
+          r.exit_code.should be_zero
+        end
+
+        shell "OS_TENANT_NAME=openstack OS_USERNAME=testuser OS_PASSWORD=123456 OS_AUTH_URL=http://127.0.0.1:5000/v2.0 swift list" do |r|
+          r.exit_code.should be_zero
+        end
+
+      end
+
+      it 'should purge all packages' do
+        puppet_apply(purge) do |r|
+          r.exit_code.should_not == 1
+        end
+      end
+    end
+  end
+
+end
+# Local Variables:
+# compile-command: "cd ../..
+#   (
+#     cd .rspec_system/vagrant_projects/one-ubuntu-server-12042-x64
+#     vagrant destroy --force
+#   )
+#   cp -a Gemfile-rspec-system Gemfile
+#   BUNDLE_PATH=/tmp/vendor bundle install --no-deployment
+#   MACHINES=first \
+#   RELEASES=dumpling \
+#   DATAS=/srv/data \
+#   RS_DESTROY=no \
+#   RS_SET=one-ubuntu-server-12042-x64 \
+#   BUNDLE_PATH=/tmp/vendor \
+#   bundle exec rake spec:system \
+#          SPEC=spec/system/ceph_rgw_keystone_spec.rb \
+#          SPEC_OPTS='--tag cephx' &&
+#   git checkout Gemfile
+# "
+# End:


### PR DESCRIPTION
Provides keystone configuration for the ceph radosgw (additional
parameters in ceph.conf).

Includes rspec puppet and rspec system tests for validation.

Closes-Bug: #1362642
Implements: blueprint rgw keystone
Change-Id: I4c3d8a78487ca94c79aea676220eb4f3bb2f144a