### PR TITLE
separate ceph-disk prepare / activate on ceph::osd

### DIFF
--- a/spec/defines/ceph_osd_spec.rb
+++ b/spec/defines/ceph_osd_spec.rb
@@ -34,7 +34,9 @@ describe 'ceph::osd' do
         '/tmp'
       end
 
-      it { should contain_exec('ceph-osd-mkfs-/tmp') }
+      it { should contain_exec('ceph-osd-prepare-/tmp') }
+
+      it { should contain_exec('ceph-osd-activate-/tmp') }
 
     end
   end
@@ -53,7 +55,9 @@ describe 'ceph::osd' do
         '/tmp'
       end
 
-      it { should contain_exec('ceph-osd-mkfs-/tmp') }
+      it { should contain_exec('ceph-osd-prepare-/tmp') }
+
+      it { should contain_exec('ceph-osd-activate-/tmp') }
 
     end
   end


### PR DESCRIPTION
separates the ceph-disk prepare and activate parts, so that we
properly handle osds that are not active but have already been prepared
(as in an unmounted partition after a reboot).

uses ceph-disk output to detect status of partitions.

Closes-Bug: #1361446

Change-Id: I201817623c3162c7247893af44cad58b20989042